### PR TITLE
Implement path-drawing on map2.html via polyline.

### DIFF
--- a/portfolio/src/main/webapp/map.html
+++ b/portfolio/src/main/webapp/map.html
@@ -5,7 +5,9 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no">
     <meta charset="utf-8">
     <style>
-      /* Always set the map height explicitly to define the size of the div
+      /* Geolocation base code from: https://developers.google.com/maps/documentation/javascript/geolocation0
+      
+      Always set the map height explicitly to define the size of the div
        * element that contains the map. */
       #map {
         height: 40%;

--- a/portfolio/src/main/webapp/map2.html
+++ b/portfolio/src/main/webapp/map2.html
@@ -39,8 +39,24 @@
           center: pos,
           zoom: 11
         });
-      }
 
+    // Draws polyline from hard-coded coordinates. Base code from: https://developers.google.com/maps/documentation/javascript/shapes
+    // TO-DO: Implement from coordinates set by organizer.
+      var pathCoordinates = [
+        {lat: 40.68, lng: -74},
+        {lat: 40.72, lng: -74},
+        {lat: 40.73, lng: -73.99}
+      ];
+      var path = new google.maps.Polyline({
+        path: pathCoordinates,
+        geodesic: true,
+        strokeColor: '#FF0000',
+        strokeOpacity: 1.0,
+        strokeWeight: 2
+      });
+
+      path.setMap(map);
+      }
     </script>
     <script async defer
     src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDQ00Z_l0PN-jiIyiUHTjn_jdnlY8HNn34&callback=initMap">


### PR DESCRIPTION
Tested out the polyline drawing also in the Maps Javascript API. Currently draws a path between a hardcoded set of three coordinates in map2.html (user view of map). These three coordinates should eventually be set on the organizer's map view and stored along with the original map-centering coodinate.
![image](https://user-images.githubusercontent.com/35279510/86830182-5d6de580-c063-11ea-8785-a49741f5eac1.png)
